### PR TITLE
Use bender 0.7 in the build workflows.

### DIFF
--- a/.github/workflows/python_docker_build.yml
+++ b/.github/workflows/python_docker_build.yml
@@ -73,7 +73,7 @@ jobs:
           password: ${{ secrets.aws_key }}
       - name: Install Bender
         run: |
-          pip install --extra-index-url https://pypi.fury.io/Pfii9sZDGkGXEhXEmStx/webgeoservices/ "bender==0.6.*"
+          pip install --extra-index-url https://pypi.fury.io/Pfii9sZDGkGXEhXEmStx/webgeoservices/ "bender==0.7.*"
       - name: Install Required Packages
         if: ${{ inputs.install }} != ''
         run: |

--- a/.github/workflows/sonar_python_bender_build.yml
+++ b/.github/workflows/sonar_python_bender_build.yml
@@ -73,7 +73,7 @@ jobs:
           password: ${{ secrets.aws_key }}
       - name: Install Bender
         run: |
-          pip install --extra-index-url https://pypi.fury.io/Pfii9sZDGkGXEhXEmStx/webgeoservices/ "bender==0.6.*"
+          pip install --extra-index-url https://pypi.fury.io/Pfii9sZDGkGXEhXEmStx/webgeoservices/ "bender==0.7.*"
       - name: Install Required Packages
         if: ${{ inputs.install }} != ''
         run: |


### PR DESCRIPTION
# Description

## What
Bender 0.7 was released so let's use that.
0.7.1 should contain an updated release command that should be used from the build helper.
