### PR TITLE
Install bender before running the release step.

### DIFF
--- a/.github/workflows/docker_deployer.yml
+++ b/.github/workflows/docker_deployer.yml
@@ -47,6 +47,9 @@ jobs:
           registry:  ${{ secrets.aws_account }}.dkr.ecr.us-east-1.amazonaws.com
           username: ${{ secrets.aws_key_id }}
           password: ${{ secrets.aws_key }}
+      - name: Install Bender
+        run: |
+          pip install --extra-index-url https://pypi.fury.io/Pfii9sZDGkGXEhXEmStx/webgeoservices/ "bender==0.7.*"
       - name: Release
         uses: ./helper/.github/actions/release
         with:


### PR DESCRIPTION

# Description
## Issue
The release step now uses bender, it works only if bender is installed.
Install bender before running the release step.

## Steps to Test or Reproduce
- Release workflow should work.


