### PR TITLE
Install bender in the sonar docker deployer workflow.

### DIFF
--- a/.github/workflows/sonar_docker_deployer.yml
+++ b/.github/workflows/sonar_docker_deployer.yml
@@ -48,6 +48,9 @@ jobs:
           registry:  ${{ secrets.aws_account }}.dkr.ecr.us-east-1.amazonaws.com
           username: ${{ secrets.aws_key_id }}
           password: ${{ secrets.aws_key }}
+      - name: Install Bender
+        run: |
+          pip install --extra-index-url https://pypi.fury.io/Pfii9sZDGkGXEhXEmStx/webgeoservices/ "bender==0.7.*"
       - name: Destroy PR Deploy
         uses: ./helper/.github/actions/deploy
         with:


### PR DESCRIPTION

# Description
## Issue
The sonar docker deployer workflow needs bender to properly work.
Install it before releasing.

## Steps to Test or Reproduce
- sonar docker deployer should work.

