### PR TITLE
Merge of How and DoD sections

### DIFF
--- a/.github/ISSUE_TEMPLATE/default.md
+++ b/.github/ISSUE_TEMPLATE/default.md
@@ -18,6 +18,11 @@ Clients | Customer Care | Sales | Marketing
 # Solution
 ## How
 <!-- How should this change be made? -->
+<!-- Explain your plan in a few sentences -->
+<!-- And, possibly provide a breakdown of the solution into small tasks/steps to track progress -->
+- [ ] task one
+- [ ] task two
+
 ### Supporting Information
 <!-- Screenshots of what you are thinking, links to websites or blogs with examples, link to a new API documentation, etc. Add them all here -->
 ### Expected Change Level
@@ -26,11 +31,6 @@ Major | Minor | Patch
 ### Dependencies
 <!-- List of other issues, teams, actions, etc. that are needed for this issue -->
 - [ ] #42
-
-# Definition of Done (DoD)
-<!-- Breakdown of this issue into smaller tasks/steps to track the progress -->
-- [ ] task one
-- [ ] task two
 
 # Acceptance Criteria (AC)
 <!-- Clearly defined expectations of the solution -->


### PR DESCRIPTION
# Description
## Issue
closes #20

## What
Make the writing of the "Solution" section of the issue template for features/improvements less confusing and increase the chances that it will be filled with useful information.

## How
Merged the DoD section into the How section and provided some simple guidance on how to fill it the resulting section.

## Related PRs
None.

# Testing
- [ ] Unit Tests cover the change
- [ ] Smoke Tests cover the change  

Manual testing, no GitHub actions are currently configured on the repo.

## Steps to Test or Reproduce
- Open `.github/ISSUE_TEMPLATE/default.md`file on Github to get a rendering,
- Click on the "Raw" button to display and check the markdown syntax.

# Ops
## Deploy
- [x] This is a standard deployment  

## Migrations
No.