### PR TITLE
Scheduled sync fork of DefinitelyTyped

### DIFF
--- a/.github/workflows/sync_forks.yml
+++ b/.github/workflows/sync_forks.yml
@@ -1,0 +1,21 @@
+name: Sync Forks
+on:
+  push:
+    branches:
+      - master
+  schedule:
+    - cron: "0 9 * * *" # At 09:00 every day
+  workflow_dispatch:
+jobs:
+  update_definitelytyped_fork:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: TobKed/github-forks-sync-action@master
+        with:
+          github_token: ${{ secrets.HELPER_TOKEN }}
+          upstream_repository: DefinitelyTyped/DefinitelyTyped
+          target_repository: woosmap/DefinitelyTyped
+          upstream_branch: master
+          target_branch: master
+          force: true
+          tags: true

--- a/.github/workflows/sync_forks.yml
+++ b/.github/workflows/sync_forks.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: TobKed/github-forks-sync-action@master
         with:
-          github_token: ${{ secrets.HELPER_TOKEN }}
+          github_token: ${{ secrets.PUBLIC_GITHUB_TOKEN }}
           upstream_repository: DefinitelyTyped/DefinitelyTyped
           target_repository: woosmap/DefinitelyTyped
           upstream_branch: master


### PR DESCRIPTION
Repository `woosmap/DefinitelyTyped` will be used to push Woosmap Map Type Definitions to npm `@types/woosmap.map`

This PR add auto sync for this project to avoid manually sync and keep up-to-date.

