### PR TITLE
Remove refrence of  `github.event.number` from action

### DIFF
--- a/.github/actions/compare_openapi/action.yml
+++ b/.github/actions/compare_openapi/action.yml
@@ -95,12 +95,13 @@ runs:
             // 0) Grab the PR payload
             const publicOwner = context.repo.owner;
             const publicRepo  = context.repo.repo;
+            const prNumber    = ${{ env.PR_NUMBER }};
             
             // 0.1) grab PR details
             const { data: pr } = await github.request('GET /repos/{owner}/{repo}/pulls/{pull_number}', {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: ${{ env.PR_NUMBER }}
+              owner: publicOwner,
+              repo: publicRepo,
+              pull_number: prNumber
             });
 
             // 1) Prepare private target repo


### PR DESCRIPTION
<!-- The title of the PR ↑↑↑ above should provide a general summary of what it is about. -->
<!-- Warning: any PR that has missing info is not ready to be reviewed. -->

## Issue
<!-- Link the PR to one or more tasks/epics/bugs. -->
<!-- Use # followed by the issue ID. 
#1234 or closes #1234 or closes Woosmap/woosmap#1234
-->

## Describe your changes
Since `github.event.number` is only available during PR creation, the action is modified to accept the PR number as an environment input. 

## How to test
<!-- Describe how to test your change. This is probably the most important part of a PR, DO NOT LEAVE IT EMPTY --> 

## Checklist:
<!-- Please go through this list. Don't just tick the boxes, verify each one. -->

- [x] My code follows the style guidelines for this repo
- [x] My code passes the SonarCloud check and does not add new code smells
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings/errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I don't require ops changes for this PR to go to prod
- [x] This change does not include a migration

### Documentation
<!-- Create issues to track any required documentation changes and include them here -->

### Libs/SDKs
<!-- Create issues to track any required library or SDK changes and include them here -->
