### PR TITLE
fix(ci): prevent shell injection in reusable workflows and action

### DIFF
--- a/.github/actions/checkout_build_helper/action.yml
+++ b/.github/actions/checkout_build_helper/action.yml
@@ -16,11 +16,14 @@ runs:
   steps:
     - name: Getting Build-Helper Tag
       shell: bash
+      env:
+        BUILD_HELPER_BRANCH: ${{ inputs.build_helper_branch }}
+        HELPER_TOKEN: ${{ inputs.helper_token }}
       run: |
-        if [ -n "${{ inputs.build_helper_branch }}" ]; then
-          echo "HELPER_VERSION=${{ inputs.build_helper_branch }}" >> $GITHUB_ENV
+        if [ -n "$BUILD_HELPER_BRANCH" ]; then
+          echo "HELPER_VERSION=$BUILD_HELPER_BRANCH" >> $GITHUB_ENV
         else
-          echo "HELPER_VERSION=$(git ls-remote --tags --sort="v:refname" https://${{ inputs.helper_token }}@github.com/Woosmap/build-helper.git v8.\* | awk '{print $2}' | tail -n 1)" >> $GITHUB_ENV
+          echo "HELPER_VERSION=$(git ls-remote --tags --sort="v:refname" "https://${HELPER_TOKEN}@github.com/Woosmap/build-helper.git" v8.\* | awk '{print $2}' | tail -n 1)" >> $GITHUB_ENV
         fi
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/python_docker_build.yml
+++ b/.github/workflows/python_docker_build.yml
@@ -51,8 +51,10 @@ jobs:
       DOCKER_BUILDKIT: 1
     steps:
       - name: Set Env Vars
+        env:
+          ENVS: ${{ inputs.envs }}
         run: |
-          IFS=', ' read -r -a array <<< "${{ inputs.envs }}"
+          IFS=', ' read -r -a array <<< "$ENVS"
           for str in "${array[@]}"; do
             echo "${str}" >> $GITHUB_ENV
           done
@@ -83,9 +85,11 @@ jobs:
         run: |
           pip install --break-system-packages --extra-index-url https://pypi.fury.io/Pfii9sZDGkGXEhXEmStx/webgeoservices/ "bender<4"
       - name: Install Required Packages
-        if: ${{ inputs.install }} != ''
+        if: ${{ inputs.install != '' }}
+        env:
+          INSTALL: ${{ inputs.install }}
         run: |
-          sudo apt install --no-install-recommends --yes ${{ inputs.install }}
+          sudo apt install --no-install-recommends --yes ${INSTALL}
       - name: Download GeoIP (maxmind) DB (for woosmapreco)
         if: ${{ env.is_reco }}
         run: |

--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -82,12 +82,12 @@ jobs:
         if: "${{ inputs.regression_tests != '' }}"
         run: |
           if [ -d "./zoidberg_tests" ]; then
-            if [[ ${{ inputs.pr_deploy }} == true ]]; then
-              output=$(zoidberg -d ./zoidberg_tests -p ${{ inputs.pr }} ${{ inputs.regression_tests }} -v)
+            if [[ "$PR_DEPLOY" == true ]]; then
+              output=$(zoidberg -d ./zoidberg_tests -p "$PR" $REGRESSION_TESTS -v)
             else
-              output=$(zoidberg -d ./zoidberg_tests ${{ inputs.regression_tests }} -v)
+              output=$(zoidberg -d ./zoidberg_tests $REGRESSION_TESTS -v)
             fi
-            
+
             result=$(echo $output | tail -1 | tr -d '[:space:]')
             echo "Result : $result"
             if [[ $result != "success" ]]; then
@@ -96,5 +96,8 @@ jobs:
             fi
           fi
         env:
+          PR_DEPLOY: ${{ inputs.pr_deploy }}
+          PR: ${{ inputs.pr }}
+          REGRESSION_TESTS: ${{ inputs.regression_tests }}
           WOOSMAP_DEVELOP_API_KEY: ${{ secrets.woosmap_develop_api_key }}
           WOOSMAP_PROD_API_KEY: ${{ secrets.woosmap_prod_api_key }}

--- a/.github/workflows/sonar_python_bender_build.yml
+++ b/.github/workflows/sonar_python_bender_build.yml
@@ -90,8 +90,10 @@ jobs:
           pip install --break-system-packages --extra-index-url https://pypi.fury.io/Pfii9sZDGkGXEhXEmStx/webgeoservices/ "bender<4"
       - name: Install Required Packages
         if: ${{ inputs.install != '' }}
+        env:
+          INSTALL: ${{ inputs.install }}
         run: |
-          sudo apt install --no-install-recommends --yes ${{ inputs.install }}
+          sudo apt install --no-install-recommends --yes ${INSTALL}
       - name: Download GeoIP (maxmind) DB (for woosmapreco)
         if: ${{ env.is_reco }}
         run: |


### PR DESCRIPTION
## What

Fixes 5 `run-shell-injection` SAST findings (high) across the reusable
workflows and the `checkout_build_helper` composite action. In each case a
caller-supplied `inputs.*` expression was interpolated directly into a `run:`
shell block via `${{ }}`, which is **template injection**: a value containing
`;`, `|`, or `$()` would be substituted into the script *before* the shell runs
and executed as runner commands.

## Fix

Move each expression into a step-level `env:` block and reference the shell
variable instead. An expanded shell variable is treated as **data** — shell
metacharacters in it are not re-parsed as commands — which is the
GitHub-recommended remediation.

| File | Inputs moved to `env:` |
|------|------------------------|
| `.github/workflows/python_docker_build.yml` | `envs`, `install` |
| `.github/workflows/sonar_python_bender_build.yml` | `install` |
| `.github/workflows/smoke_test.yml` | `pr_deploy`, `pr`, `regression_tests` |
| `.github/actions/checkout_build_helper/action.yml` | `build_helper_branch`, `helper_token` |

Quoting notes:
- `"$PR_DEPLOY"`, `"$PR"`, `"$BUILD_HELPER_BRANCH"`, clone URL — quoted.
- `${INSTALL}` and `$REGRESSION_TESTS` — intentionally left unquoted to preserve
  their existing use as multiple CLI args / package names (word-splitting is the
  desired behavior; command execution is no longer possible).

Also corrected the fragile `if: ${{ inputs.install }} != ''` in
`python_docker_build.yml` to `if: ${{ inputs.install != '' }}` — the old form
renders a malformed expression when `install` holds multiple packages.

## Compatibility

No `workflow_call` input, secret, or composite-action input/output **interface**
changed — only the internal `run:` step bodies. Existing callers across Woosmap
repos are unaffected.

## Verification

- YAML parses for all four files.
- `actionlint` reports no new errors — only pre-existing `info`-level `SC2086`
  notes (on `$GITHUB_ENV` and the intentional `${INSTALL}` splitting) and
  unrelated pre-existing `workflow_call` default/required warnings.

Closes 5 Bastion `run-shell-injection` findings (high) on this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
