### PR TITLE
Allow SonarCloud scan step to fail without failing build

### DIFF
--- a/.github/workflows/sonar_docker_deployer.yml
+++ b/.github/workflows/sonar_docker_deployer.yml
@@ -95,6 +95,7 @@ jobs:
           cache_aws_key: ${{ secrets.cache_aws_key }}
       - name: SonarCloud Scan
         uses: SonarSource/sonarqube-scan-action@master
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.helper_token }}
           SONAR_TOKEN: ${{ secrets.sonar_token}}

--- a/.github/workflows/sonar_python_bender_build.yml
+++ b/.github/workflows/sonar_python_bender_build.yml
@@ -113,6 +113,7 @@ jobs:
           cache_aws_key: ${{ secrets.cache_aws_key }}
       - name: SonarCloud Scan
         uses: SonarSource/sonarqube-scan-action@master
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.helper_token }}
           SONAR_TOKEN: ${{ secrets.sonar_token}}


### PR DESCRIPTION
## Issue
N/A — SonarCloud outage.

## Describe your changes
SonarCloud is down, so the scan step fails and takes the whole reusable
workflow with it — blocking builds and deploys on every consuming repo.
Adds `continue-on-error: true` to the SonarCloud Scan step in
`sonar_docker_deployer.yml` and `sonar_python_bender_build.yml` so the
scan is best-effort and downstream steps (publish, deploy) still run.

Temporary. This silently disables the quality gate — revert once Sonar
is back up.

## How to test
Trigger either reusable workflow from a consuming repo while Sonar is
unreachable: the Scan step goes red-annotated but the job continues to
Publish/Deploy and the run ends green.

## Checklist:
- [x] My code follows the style guidelines for this repo
- [ ] My code passes the SonarCloud check and does not add new code smells
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings/errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I don't require ops changes for this PR to go to prod
- [x] This change does not include a migration

### Documentation
N/A

### Libs/SDKs
N/A
